### PR TITLE
feat: JWT 인증 필터 추가 및 고정 Secret Key 적용

### DIFF
--- a/src/main/java/com/market/needa/infrastructure/config/WebSecurityConfig.java
+++ b/src/main/java/com/market/needa/infrastructure/config/WebSecurityConfig.java
@@ -1,5 +1,9 @@
 package com.market.needa.infrastructure.config;
 
+import com.market.needa.application.token.TokenService;
+import com.market.needa.infrastructure.jwt.TokenAuthenticationFilter;
+import com.market.needa.infrastructure.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +16,9 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+@RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 public class WebSecurityConfig {
@@ -36,7 +42,7 @@ public class WebSecurityConfig {
      * @throws Exception HttpSecurity 구성 중 오류가 발생할 경우
      */
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, TokenAuthenticationFilter tokenAuthenticationFilter) throws Exception {
         http
             .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                     .requestMatchers("/", "/login", "/signup",
@@ -44,6 +50,7 @@ public class WebSecurityConfig {
                             "/static/**", "/user/**").permitAll()
                     .anyRequest().authenticated()
             )
+            .addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .formLogin(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
             .csrf(AbstractHttpConfigurer::disable)
@@ -51,6 +58,11 @@ public class WebSecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
+    }
+
+    @Bean
+    public TokenAuthenticationFilter tokenAuthenticationFilter(TokenService tokenService, TokenProvider tokenProvider) {
+        return new TokenAuthenticationFilter(tokenProvider, tokenService);
     }
 
     /**

--- a/src/main/java/com/market/needa/infrastructure/jwt/JwtProperties.java
+++ b/src/main/java/com/market/needa/infrastructure/jwt/JwtProperties.java
@@ -12,4 +12,5 @@ import org.springframework.stereotype.Component;
 public class JwtProperties {
 
     private String issuer;
+    private String secretKey;
 }


### PR DESCRIPTION
## 변경 내용
1. `TokenAuthenticationFilter`를 `SecurityFilterChain`에 추가하여 JWT 기반 인증을 적용
2. Secret Key를 동적으로 생성하던 방식에서 고정된 Secret Key를 사용하는 방식으로 변경함
3. JWT 서명 및 검증 로직에서 고정된 Secret Key를 사용하여 서버 재시작 시에도 기존 토큰 인증이 유지되도록 개선

## 변경 이유
- 서버 재시작 시 매번 Secret Key가 변경되어 기존에 발급된 JWT가 더 이상 유효하지 않는 문제를 해결하기 위해 수정
   - 보안 강화를 위해 동적인 Secret Key 생성 방식 대신 설정 파일에 고정 Secret Key를 관리하도록 변경
- JWT 토큰 인증의 안정성과 확장성을 위해 필터 체인을 업데이트하고 토큰 인증 플로우를 명확히 구현

## 주요 변경 코드
1. `TokenAuthenticationFilter`가 SecurityFilterChain(`WebSecurityConfig.securityFilterChain`)에 등록
2. `TokenProvider`에서 Secret Key를 고정 값으로 설정하고, `JwtProperties`에서 Secret Key를 로드하도록 수정

## 테스트

- [x] 서버 재시작 후에도 기존 JWT로 인증 가능 여부를 확인
- [x] 올바르지 않은 JWT로 요청 시 오류 반환 확인
